### PR TITLE
follow links repeatedly until no new segment assignments are found

### DIFF
--- a/segmenter.py
+++ b/segmenter.py
@@ -88,16 +88,20 @@ def main(params):
 
 
     # Check for links of unknown nodes to nodes in other segments
-    collector = []
-    for id,n in unknown["nodes"].items():
-        if (id in links):
-            target = links[id]
-            if (target in nodes):
-                if ("segment" in nodes[target]):
-                    nodes[target]["segment"]["nodes"][id] = n
-                    collector.append(id)
-    for id in collector:
-        del unknown["nodes"][id]
+    done = False
+    while not done:
+        done = True
+        collector = []
+        for id,n in unknown["nodes"].items():
+            if (id in links):
+                target = links[id]
+                if (target in nodes):
+                    if ("segment" in nodes[target]):
+                        nodes[target]["segment"]["nodes"][id] = n
+                        collector.append(id)
+                        done = False
+        for id in collector:
+            del unknown["nodes"][id]
 
     segments.append(unknown);
 


### PR DESCRIPTION
Müsste man die Links nicht eigentlich wiederholt durchgehen, um wirklich alle Nodes einzufangen? (Im Moment scheint das allerdings keinen Unterschied zu machen, die Ausgabe ist identisch)
